### PR TITLE
optimize battery usage: screen off detection, event throttling, trimmed event types

### DIFF
--- a/app/src/main/java/net/kollnig/greasemilkyway/DistractionControlService.java
+++ b/app/src/main/java/net/kollnig/greasemilkyway/DistractionControlService.java
@@ -54,6 +54,14 @@ public class DistractionControlService extends BaseDistractionControlService {
     }
 
     @Override
+    protected long getNotificationTimeout() {
+        if (config == null) {
+            config = new ServiceConfig(this);
+        }
+        return config.getNotificationTimeoutMs();
+    }
+
+    @Override
     protected void onServiceReady() {
         instance = this;
         config = new ServiceConfig(this);

--- a/app/src/main/java/net/kollnig/greasemilkyway/ServiceConfig.java
+++ b/app/src/main/java/net/kollnig/greasemilkyway/ServiceConfig.java
@@ -26,6 +26,7 @@ public class ServiceConfig {
     private static final String KEY_PAUSE_UNTIL_PACKAGE_ = "pause_until_package_";
     private static final String KEY_FRICTION_WORD_COUNT = "friction_word_count";
     private static final String KEY_PAUSE_DURATION_MINS = "pause_duration_mins";
+    private static final String KEY_NOTIFICATION_TIMEOUT_MS = "notification_timeout_ms";
     private static final String DEFAULT_RULES_FILE = "distraction_rules.txt";
 
     private final SharedPreferences prefs;
@@ -175,6 +176,14 @@ public class ServiceConfig {
 
     public void setPauseDurationMins(int mins) {
         prefs.edit().putInt(KEY_PAUSE_DURATION_MINS, mins).apply();
+    }
+
+    public long getNotificationTimeoutMs() {
+        return prefs.getLong(KEY_NOTIFICATION_TIMEOUT_MS, 100);
+    }
+
+    public void setNotificationTimeoutMs(long ms) {
+        prefs.edit().putLong(KEY_NOTIFICATION_TIMEOUT_MS, ms).apply();
     }
 
     public String[] getCustomRules() {

--- a/app/src/main/java/net/kollnig/greasemilkyway/SettingsActivity.java
+++ b/app/src/main/java/net/kollnig/greasemilkyway/SettingsActivity.java
@@ -94,14 +94,31 @@ public class SettingsActivity extends AppCompatActivity {
             updateSubtitles();
         }));
 
-        findViewById(R.id.btn_notification_timeout).setOnClickListener(v -> showNumberPickerDialog("Event Throttle", "Minimum ms between events. Higher = less battery use, but slower response (0-500)", 0, 500, (int) config.getNotificationTimeoutMs(), newValue -> {
-            config.setNotificationTimeoutMs(newValue);
-            updateSubtitles();
-            DistractionControlService svc = DistractionControlService.getInstance();
-            if (svc != null) {
-                svc.updateRules();
+        findViewById(R.id.btn_notification_timeout).setOnClickListener(v -> {
+            final String[] labels = {"Immediate response", "Default (recommended)", "Battery saver"};
+            final long[] values = {0, 100, 300};
+            long current = config.getNotificationTimeoutMs();
+            int checkedItem = 1;
+            for (int i = 0; i < values.length; i++) {
+                if (values[i] == current) {
+                    checkedItem = i;
+                    break;
+                }
             }
-        }));
+            new AlertDialog.Builder(this)
+                .setTitle("Response Speed")
+                .setSingleChoiceItems(labels, checkedItem, (dialog, which) -> {
+                    config.setNotificationTimeoutMs(values[which]);
+                    updateSubtitles();
+                    DistractionControlService svc = DistractionControlService.getInstance();
+                    if (svc != null) {
+                        svc.updateRules();
+                    }
+                    dialog.dismiss();
+                })
+                .setNegativeButton(android.R.string.cancel, null)
+                .show();
+        });
     }
 
     private void updateSubtitles() {
@@ -112,7 +129,16 @@ public class SettingsActivity extends AppCompatActivity {
             tvPauseDurationSubtitle.setText(getString(R.string.pause_duration_minutes, config.getPauseDurationMins()));
         }
         if (tvNotificationTimeoutSubtitle != null) {
-            tvNotificationTimeoutSubtitle.setText(getString(R.string.notification_timeout_ms, (int) config.getNotificationTimeoutMs()));
+            long ms = config.getNotificationTimeoutMs();
+            String label;
+            if (ms <= 0) {
+                label = getString(R.string.response_speed_immediate);
+            } else if (ms >= 300) {
+                label = getString(R.string.response_speed_battery_saver);
+            } else {
+                label = getString(R.string.response_speed_default);
+            }
+            tvNotificationTimeoutSubtitle.setText(label);
         }
     }
 

--- a/app/src/main/java/net/kollnig/greasemilkyway/SettingsActivity.java
+++ b/app/src/main/java/net/kollnig/greasemilkyway/SettingsActivity.java
@@ -28,6 +28,7 @@ public class SettingsActivity extends AppCompatActivity {
     private ServiceConfig config;
     private TextView tvFrictionGateSubtitle;
     private TextView tvPauseDurationSubtitle;
+    private TextView tvNotificationTimeoutSubtitle;
 
     private final ActivityResultLauncher<Intent> frictionGateLauncher =
             registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), result -> {
@@ -77,7 +78,8 @@ public class SettingsActivity extends AppCompatActivity {
         
         tvFrictionGateSubtitle = findViewById(R.id.tv_friction_gate_subtitle);
         tvPauseDurationSubtitle = findViewById(R.id.tv_pause_duration_subtitle);
-        
+        tvNotificationTimeoutSubtitle = findViewById(R.id.tv_notification_timeout_subtitle);
+
         updateSubtitles();
 
         findViewById(R.id.btn_custom_rules).setOnClickListener(v -> startActivity(new Intent(SettingsActivity.this, CustomRulesActivity.class)));
@@ -91,6 +93,15 @@ public class SettingsActivity extends AppCompatActivity {
             config.setPauseDurationMins(newValue);
             updateSubtitles();
         }));
+
+        findViewById(R.id.btn_notification_timeout).setOnClickListener(v -> showNumberPickerDialog("Event Throttle", "Minimum ms between events. Higher = less battery use, but slower response (0-500)", 0, 500, (int) config.getNotificationTimeoutMs(), newValue -> {
+            config.setNotificationTimeoutMs(newValue);
+            updateSubtitles();
+            DistractionControlService svc = DistractionControlService.getInstance();
+            if (svc != null) {
+                svc.updateRules();
+            }
+        }));
     }
 
     private void updateSubtitles() {
@@ -99,6 +110,9 @@ public class SettingsActivity extends AppCompatActivity {
         }
         if (tvPauseDurationSubtitle != null) {
             tvPauseDurationSubtitle.setText(getString(R.string.pause_duration_minutes, config.getPauseDurationMins()));
+        }
+        if (tvNotificationTimeoutSubtitle != null) {
+            tvNotificationTimeoutSubtitle.setText(getString(R.string.notification_timeout_ms, (int) config.getNotificationTimeoutMs()));
         }
     }
 

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -116,6 +116,33 @@
                     android:layout_marginTop="4dp" />
             </LinearLayout>
 
+            <!-- Notification Timeout (Battery Saver) -->
+            <LinearLayout
+                android:id="@+id/btn_notification_timeout"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="?attr/selectableItemBackground"
+                android:clickable="true"
+                android:focusable="true"
+                android:orientation="vertical"
+                android:padding="16dp">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/notification_timeout_title"
+                    android:textAppearance="?attr/textAppearanceSubtitle1" />
+
+                <TextView
+                    android:id="@+id/tv_notification_timeout_subtitle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/notification_timeout_subtitle_default"
+                    android:textAppearance="?attr/textAppearanceBody2"
+                    android:textColor="?android:attr/textColorSecondary"
+                    android:layout_marginTop="4dp" />
+            </LinearLayout>
+
         </LinearLayout>
     </androidx.core.widget.NestedScrollView>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -110,4 +110,7 @@
     <!-- Settings subtitle defaults (overridden at runtime) -->
     <string name="friction_gate_subtitle_default">Current: 0 words</string>
     <string name="pause_duration_subtitle_default">Current: 10 mins</string>
+    <string name="notification_timeout_title">Event Throttle (Battery Saver)</string>
+    <string name="notification_timeout_subtitle_default">Current: 100 ms</string>
+    <string name="notification_timeout_ms">%d ms</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -110,7 +110,9 @@
     <!-- Settings subtitle defaults (overridden at runtime) -->
     <string name="friction_gate_subtitle_default">Current: 0 words</string>
     <string name="pause_duration_subtitle_default">Current: 10 mins</string>
-    <string name="notification_timeout_title">Event Throttle (Battery Saver)</string>
-    <string name="notification_timeout_subtitle_default">Current: 100 ms</string>
-    <string name="notification_timeout_ms">%d ms</string>
+    <string name="notification_timeout_title">Response Speed</string>
+    <string name="notification_timeout_subtitle_default">Default</string>
+    <string name="response_speed_immediate">Immediate response</string>
+    <string name="response_speed_default">Default</string>
+    <string name="response_speed_battery_saver">Battery saver</string>
 </resources>

--- a/app/src/main/res/xml/accessibility_service_config.xml
+++ b/app/src/main/res/xml/accessibility_service_config.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
-    android:accessibilityEventTypes="typeWindowStateChanged|typeWindowContentChanged|typeViewScrolled|typeViewClicked|typeViewFocused"
+    android:accessibilityEventTypes="typeWindowStateChanged|typeWindowContentChanged|typeViewScrolled"
     android:accessibilityFeedbackType="feedbackGeneric"
     android:accessibilityFlags="flagReportViewIds"
     android:canRetrieveWindowContent="true"
     android:description="@string/accessibility_service_description"
-    android:notificationTimeout="0"
+    android:notificationTimeout="100"
     android:isAccessibilityTool="true" />

--- a/distractionlib/src/main/java/net/kollnig/distractionlib/BaseDistractionControlService.java
+++ b/distractionlib/src/main/java/net/kollnig/distractionlib/BaseDistractionControlService.java
@@ -3,7 +3,10 @@ package net.kollnig.distractionlib;
 import android.accessibilityservice.AccessibilityService;
 import android.accessibilityservice.AccessibilityServiceInfo;
 import android.annotation.SuppressLint;
+import android.content.BroadcastReceiver;
+import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.graphics.Color;
@@ -41,7 +44,9 @@ public abstract class BaseDistractionControlService extends AccessibilityService
     private WindowManager windowManager;
     private boolean isDarkMode;
     private boolean sentinelPackagesActive;
+    private boolean screenOn = true;
     private String cachedLauncherPackage;
+    private BroadcastReceiver screenReceiver;
 
     private final Runnable processEvent = () -> {
         try {
@@ -88,6 +93,14 @@ public abstract class BaseDistractionControlService extends AccessibilityService
     protected abstract void onServiceReady();
 
     protected abstract void onServiceTeardown();
+
+    /**
+     * Returns the notification timeout in milliseconds for the accessibility service.
+     * Higher values reduce event frequency and save battery. Default is 100ms.
+     */
+    protected long getNotificationTimeout() {
+        return 100;
+    }
 
     protected void onRulesReloaded() {
     }
@@ -148,11 +161,33 @@ public abstract class BaseDistractionControlService extends AccessibilityService
                 return;
             }
             updateDarkMode();
+            registerScreenReceiver();
             onServiceReady();
             reloadRulesFromSource();
         } catch (Exception e) {
             Log.e(getLogTag(), "Error initializing service", e);
         }
+    }
+
+    private void registerScreenReceiver() {
+        screenReceiver = new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context context, Intent intent) {
+                if (Intent.ACTION_SCREEN_OFF.equals(intent.getAction())) {
+                    screenOn = false;
+                    Log.d(getLogTag(), "Screen off - pausing accessibility processing");
+                    ui.removeCallbacks(processEvent);
+                    forceClearAllOverlays();
+                } else if (Intent.ACTION_SCREEN_ON.equals(intent.getAction())) {
+                    screenOn = true;
+                    Log.d(getLogTag(), "Screen on - resuming accessibility processing");
+                }
+            }
+        };
+        IntentFilter filter = new IntentFilter();
+        filter.addAction(Intent.ACTION_SCREEN_OFF);
+        filter.addAction(Intent.ACTION_SCREEN_ON);
+        registerReceiver(screenReceiver, filter);
     }
 
     @Override
@@ -168,7 +203,7 @@ public abstract class BaseDistractionControlService extends AccessibilityService
 
     @Override
     public void onAccessibilityEvent(AccessibilityEvent event) {
-        if (event == null) {
+        if (event == null || !screenOn) {
             return;
         }
 
@@ -223,6 +258,7 @@ public abstract class BaseDistractionControlService extends AccessibilityService
                 return;
             }
             info.flags |= AccessibilityServiceInfo.FLAG_REPORT_VIEW_IDS;
+            info.notificationTimeout = getNotificationTimeout();
 
             Set<String> packages = new HashSet<>();
             for (FilterRule rule : rules) {
@@ -604,6 +640,12 @@ public abstract class BaseDistractionControlService extends AccessibilityService
         super.onDestroy();
         try {
             onServiceTeardown();
+            if (screenReceiver != null) {
+                try {
+                    unregisterReceiver(screenReceiver);
+                } catch (Exception ignored) {
+                }
+            }
         } finally {
             forceClearAllOverlays();
         }

--- a/distractionlib/src/main/java/net/kollnig/distractionlib/BaseDistractionControlService.java
+++ b/distractionlib/src/main/java/net/kollnig/distractionlib/BaseDistractionControlService.java
@@ -14,6 +14,7 @@ import android.graphics.PixelFormat;
 import android.graphics.Rect;
 import android.os.Handler;
 import android.os.Looper;
+import android.os.PowerManager;
 import android.util.Log;
 import android.view.Gravity;
 import android.view.View;
@@ -170,6 +171,12 @@ public abstract class BaseDistractionControlService extends AccessibilityService
     }
 
     private void registerScreenReceiver() {
+        PowerManager pm = (PowerManager) getSystemService(POWER_SERVICE);
+        if (pm != null) {
+            screenOn = pm.isInteractive();
+            Log.d(getLogTag(), "Initial screen state: " + (screenOn ? "on" : "off"));
+        }
+
         screenReceiver = new BroadcastReceiver() {
             @Override
             public void onReceive(Context context, Intent intent) {


### PR DESCRIPTION
- Add screen on/off BroadcastReceiver to pause all accessibility processing
  when screen is locked (primary fix for battery drain and phone heating)
- Add configurable notification timeout setting (event throttle) in Settings,
  default 100ms instead of 0ms, reducing event frequency
- Remove typeViewClicked and typeViewFocused from accessibility config XML
  since they were received but never processed in code
- Keep systemui sentinel for app switcher/notification shade overlay cleanup

https://claude.ai/code/session_01Qdn6mvDyTxMXYCKB6Rhsvq