### PR TITLE
Fix rule toggle not visually disabling after friction gate

### DIFF
--- a/app/src/main/java/net/kollnig/greasemilkyway/MainActivity.java
+++ b/app/src/main/java/net/kollnig/greasemilkyway/MainActivity.java
@@ -41,10 +41,11 @@ public class MainActivity extends AppCompatActivity {
             registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), result -> {
                 if (result.getResultCode() == RESULT_OK && onFrictionGatePassed != null) {
                     onFrictionGatePassed.run();
+                } else {
+                    // Friction gate was cancelled - reload to restore switch state and listeners
+                    loadSettings();
                 }
                 onFrictionGatePassed = null;
-                // Re-enable UI or rebuild list if needed
-                loadSettings();
             });
 
     @Override


### PR DESCRIPTION
loadSettings() was called unconditionally after the friction gate
completed, replacing currentRules with fresh objects (enabled=true from
SharedPreferences) before the pause dialog was acted on. When the dialog
callback then called rebuildItemsList(), the state-preservation logic
copied the stale enabled=true back, overwriting the disabled state.

Fix: only call loadSettings() when the friction gate is cancelled
(to reset the reverted toggle). When the gate passes, the dialog
callbacks already call rebuildItemsList() with the correct state.

https://claude.ai/code/session_012kdMWGkfWvTWL9aoXeygPS