### PR TITLE
Fix overlays not clearing immediately when opening app switcher

### DIFF
--- a/distractionlib/src/main/java/net/kollnig/distractionlib/BaseDistractionControlService.java
+++ b/distractionlib/src/main/java/net/kollnig/distractionlib/BaseDistractionControlService.java
@@ -219,10 +219,8 @@ public abstract class BaseDistractionControlService extends AccessibilityService
         if (packageName.equals(getPackageName())
                 || packageName.equals("com.android.systemui")
                 || isLauncherPackage(packageName)) {
-            if (event.getEventType() == AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED) {
-                ui.removeCallbacks(processEvent);
-                forceClearAllOverlays();
-            }
+            ui.removeCallbacks(processEvent);
+            forceClearAllOverlays();
             return;
         }
 


### PR DESCRIPTION
The overlay clear was gated on TYPE_WINDOW_STATE_CHANGED events from
systemui/launcher, but the app switcher can fire other event types first
(or the recents screen fires events before the state change arrives).
Remove the event type gate so overlays are cleared on any event from
systemui or the launcher package.

https://claude.ai/code/session_01ToyFCDRjH9j6i8H1HdpuTU