### PR TITLE
Fix overlay flicker and removal race conditions

### DIFF
--- a/distractionlib/src/main/java/net/kollnig/distractionlib/BaseDistractionControlService.java
+++ b/distractionlib/src/main/java/net/kollnig/distractionlib/BaseDistractionControlService.java
@@ -35,12 +35,16 @@ import java.util.Set;
 @SuppressLint("AccessibilityPolicy")
 public abstract class BaseDistractionControlService extends AccessibilityService {
     private static final int MAX_OVERLAY_COUNT = 100;
+    // Absorbs transient foreign-window events (notification shade, status bar
+    // updates) that briefly take focus while the target app remains below.
+    private static final long CLEAR_OVERLAYS_DELAY_MS = 150;
 
     private final List<FilterRule> rules = new ArrayList<>();
     private final Handler ui = new Handler(Looper.getMainLooper());
     private final OverlayManager overlayManager = new OverlayManager();
     private final Map<String, BlockedElement> blockedElements = new HashMap<>();
     private final Set<String> activeRuleKeys = new HashSet<>();
+    private final Runnable pendingClear = this::forceClearAllOverlays;
 
     private WindowManager windowManager;
     private boolean isDarkMode;
@@ -120,6 +124,7 @@ public abstract class BaseDistractionControlService extends AccessibilityService
 
     protected final void reloadRulesFromSource() {
         ui.removeCallbacks(processEvent);
+        ui.removeCallbacks(pendingClear);
         rules.clear();
         List<FilterRule> loadedRules = loadRules();
         if (loadedRules != null) {
@@ -133,6 +138,7 @@ public abstract class BaseDistractionControlService extends AccessibilityService
 
     protected final void reevaluateBlockingState() {
         ui.removeCallbacks(processEvent);
+        ui.removeCallbacks(pendingClear);
         if (!shouldProcessRules()) {
             forceClearAllOverlays();
             return;
@@ -184,6 +190,7 @@ public abstract class BaseDistractionControlService extends AccessibilityService
                     screenOn = false;
                     Log.d(getLogTag(), "Screen off - pausing accessibility processing");
                     ui.removeCallbacks(processEvent);
+                    ui.removeCallbacks(pendingClear);
                     forceClearAllOverlays();
                 } else if (Intent.ACTION_SCREEN_ON.equals(intent.getAction())) {
                     screenOn = true;
@@ -214,31 +221,43 @@ public abstract class BaseDistractionControlService extends AccessibilityService
             return;
         }
 
-        String packageName = event.getPackageName() != null ? event.getPackageName().toString() : "";
-
-        if (packageName.equals(getPackageName())
-                || packageName.equals("com.android.systemui")
-                || isLauncherPackage(packageName)) {
-            ui.removeCallbacks(processEvent);
-            forceClearAllOverlays();
-            return;
-        }
-
-        if (!hasMatchingRule(packageName)) {
-            ui.removeCallbacks(processEvent);
-            forceClearAllOverlays();
-            return;
-        }
-
-        if (!shouldProcessRules()) {
-            forceClearAllOverlays();
-            return;
-        }
-
         int eventType = event.getEventType();
         if (eventType != AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED
                 && eventType != AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED
                 && eventType != AccessibilityEvent.TYPE_VIEW_SCROLLED) {
+            return;
+        }
+
+        String packageName = event.getPackageName() != null ? event.getPackageName().toString() : "";
+
+        boolean isNonTarget = packageName.equals(getPackageName())
+                || packageName.equals("com.android.systemui")
+                || isLauncherPackage(packageName)
+                || !hasMatchingRule(packageName);
+
+        if (isNonTarget) {
+            // Only a window-state change is a definitive leave signal. Content
+            // changes / scrolls from systemui or the launcher can fire while
+            // the target app is still the active window below (e.g. a new
+            // notification arriving, or status bar animation).
+            if (eventType == AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED) {
+                ui.removeCallbacks(processEvent);
+                ui.removeCallbacks(pendingClear);
+                // Delay the clear so a quick shade pull-and-release, or a
+                // transient launcher preview, does not cause the overlay to
+                // disappear and immediately reappear. A real app switch still
+                // clears within CLEAR_OVERLAYS_DELAY_MS.
+                ui.postDelayed(pendingClear, CLEAR_OVERLAYS_DELAY_MS);
+            }
+            return;
+        }
+
+        // Target package event — cancel any pending clear from a transient
+        // foreign window, then re-evaluate overlays.
+        ui.removeCallbacks(pendingClear);
+
+        if (!shouldProcessRules()) {
+            forceClearAllOverlays();
             return;
         }
 
@@ -637,6 +656,7 @@ public abstract class BaseDistractionControlService extends AccessibilityService
 
     @Override
     public void onInterrupt() {
+        ui.removeCallbacks(pendingClear);
         forceClearAllOverlays();
     }
 
@@ -644,6 +664,8 @@ public abstract class BaseDistractionControlService extends AccessibilityService
     public void onDestroy() {
         super.onDestroy();
         try {
+            ui.removeCallbacks(processEvent);
+            ui.removeCallbacks(pendingClear);
             onServiceTeardown();
             if (screenReceiver != null) {
                 try {

--- a/distractionlib/src/main/java/net/kollnig/distractionlib/BaseDistractionControlService.java
+++ b/distractionlib/src/main/java/net/kollnig/distractionlib/BaseDistractionControlService.java
@@ -79,7 +79,7 @@ public abstract class BaseDistractionControlService extends AccessibilityService
                 for (String key : toRemove) {
                     BlockedElement element = blockedElements.remove(key);
                     if (element != null) {
-                        overlayManager.removeOverlay(element.overlay, windowManager, ui);
+                        overlayManager.removeOverlay(element.overlay, windowManager);
                     }
                 }
                 removeSentinelsIfIdle();
@@ -599,7 +599,7 @@ public abstract class BaseDistractionControlService extends AccessibilityService
                     WindowManager.LayoutParams.TYPE_ACCESSIBILITY_OVERLAY, flags,
                     PixelFormat.TRANSLUCENT);
             lp.gravity = Gravity.TOP | Gravity.START;
-            overlayManager.updateOverlay(existing.overlay, lp, windowManager, ui);
+            overlayManager.updateOverlay(existing.overlay, lp, windowManager);
             existing.bounds.set(area);
             return;
         }
@@ -628,7 +628,7 @@ public abstract class BaseDistractionControlService extends AccessibilityService
                 PixelFormat.TRANSLUCENT);
         lp.gravity = Gravity.TOP | Gravity.START;
 
-        overlayManager.addOverlay(blocker, lp, windowManager, ui);
+        overlayManager.addOverlay(blocker, lp, windowManager);
         blockedElements.put(ruleKey, new BlockedElement(blocker, new Rect(area)));
 
         if (!sentinelPackagesActive) {
@@ -637,15 +637,13 @@ public abstract class BaseDistractionControlService extends AccessibilityService
     }
 
     private void clearAllOverlays() {
-        overlayManager.clearOverlays(windowManager, ui);
+        overlayManager.clearOverlays(windowManager);
         blockedElements.clear();
         removeSentinelsIfIdle();
     }
 
     private void forceClearAllOverlays() {
-        overlayManager.forceClearOverlays(windowManager);
-        blockedElements.clear();
-        removeSentinelsIfIdle();
+        clearAllOverlays();
     }
 
     private void removeSentinelsIfIdle() {

--- a/distractionlib/src/main/java/net/kollnig/distractionlib/OverlayManager.java
+++ b/distractionlib/src/main/java/net/kollnig/distractionlib/OverlayManager.java
@@ -63,12 +63,14 @@ public class OverlayManager {
         for (View v : new ArrayList<>(overlays)) {
             ui.post(() -> {
                 try {
-                    windowManager.removeView(v);
+                    if (v.getParent() != null) {
+                        windowManager.removeView(v);
+                    }
                 } catch (Exception e) {
                     Log.e(TAG, "Error removing overlay", e);
                 }
+                overlays.remove(v);
             });
-            overlays.remove(v);
         }
     }
 

--- a/distractionlib/src/main/java/net/kollnig/distractionlib/OverlayManager.java
+++ b/distractionlib/src/main/java/net/kollnig/distractionlib/OverlayManager.java
@@ -1,82 +1,62 @@
 package net.kollnig.distractionlib;
 
-import android.os.Handler;
 import android.util.Log;
 import android.view.View;
 import android.view.WindowManager;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * Manages overlay views for blocking content.
+ *
+ * All methods must be called on the main thread (the accessibility service
+ * already dispatches events there). Operations on WindowManager and the
+ * tracking list are synchronous so callers can rely on consistent state
+ * immediately after each call — this avoids races where a queued addView
+ * runs after a clear, leaving an orphan view attached but untracked.
  */
 public class OverlayManager {
     private static final String TAG = "OverlayManager";
-    private final List<View> overlays = new CopyOnWriteArrayList<>();
+    private final List<View> overlays = new ArrayList<>();
 
     public int getOverlayCount() {
         return overlays.size();
     }
 
-    public void addOverlay(View overlay, WindowManager.LayoutParams params, WindowManager windowManager,
-                           Handler ui) {
-        ui.post(() -> {
-            try {
-                windowManager.addView(overlay, params);
-                overlays.add(overlay);
-            } catch (Exception e) {
-                Log.e(TAG, "Error adding overlay", e);
-            }
-        });
-    }
-
-    public void updateOverlay(View overlay, WindowManager.LayoutParams params,
-                              WindowManager windowManager, Handler ui) {
-        ui.post(() -> {
-            try {
-                if (overlay.getParent() != null) {
-                    windowManager.updateViewLayout(overlay, params);
-                }
-            } catch (Exception e) {
-                Log.e(TAG, "Error updating overlay", e);
-            }
-        });
-    }
-
-    public void removeOverlay(View overlay, WindowManager windowManager, Handler ui) {
-        ui.post(() -> {
-            try {
-                if (overlay.getParent() != null) {
-                    windowManager.removeView(overlay);
-                }
-                overlays.remove(overlay);
-            } catch (Exception e) {
-                Log.e(TAG, "Error removing overlay", e);
-            }
-        });
-    }
-
-    public void clearOverlays(WindowManager windowManager, Handler ui) {
-        if (overlays.isEmpty()) return;
-        for (View v : new ArrayList<>(overlays)) {
-            ui.post(() -> {
-                try {
-                    if (v.getParent() != null) {
-                        windowManager.removeView(v);
-                    }
-                } catch (Exception e) {
-                    Log.e(TAG, "Error removing overlay", e);
-                }
-                overlays.remove(v);
-            });
+    public void addOverlay(View overlay, WindowManager.LayoutParams params, WindowManager windowManager) {
+        try {
+            windowManager.addView(overlay, params);
+            overlays.add(overlay);
+        } catch (Exception e) {
+            Log.e(TAG, "Error adding overlay", e);
         }
     }
 
-    public void forceClearOverlays(WindowManager windowManager) {
-        if (overlays.isEmpty()) return;
+    public void updateOverlay(View overlay, WindowManager.LayoutParams params,
+                              WindowManager windowManager) {
+        try {
+            if (overlay.getParent() != null) {
+                windowManager.updateViewLayout(overlay, params);
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "Error updating overlay", e);
+        }
+    }
 
+    public void removeOverlay(View overlay, WindowManager windowManager) {
+        try {
+            if (overlay.getParent() != null) {
+                windowManager.removeView(overlay);
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "Error removing overlay", e);
+        }
+        overlays.remove(overlay);
+    }
+
+    public void clearOverlays(WindowManager windowManager) {
+        if (overlays.isEmpty()) return;
         for (View v : new ArrayList<>(overlays)) {
             try {
                 if (v.getParent() != null) {
@@ -85,7 +65,7 @@ public class OverlayManager {
             } catch (Exception e) {
                 Log.e(TAG, "Error removing overlay", e);
             }
-            overlays.remove(v);
         }
+        overlays.clear();
     }
 }


### PR DESCRIPTION
## Summary

Addresses two reported overlay artifacts: (1) overlays briefly disappearing and reappearing while still in the target app, and (2) overlays staying visible after leaving the app.

### Flicker — `onAccessibilityEvent` is too eager to clear
- Only `TYPE_WINDOW_STATE_CHANGED` from a foreign package now counts as a leave signal. Content changes and scrolls from `systemui` (e.g. status bar updates from an arriving notification) or the launcher no longer trigger a clear while the target app is still the active window underneath.
- Foreign window-state changes are debounced by 150ms; any subsequent event from the target package cancels the pending clear. This absorbs transient focus changes such as a briefly pulled notification shade.

### Race — `OverlayManager` add/remove was partly async, partly sync
- All `OverlayManager` operations are now synchronous on the caller's thread (always main for the accessibility service). A queued `addView` can no longer run after a `clear` and leave an orphan view attached but untracked.
- `clearOverlays` can no longer empty the tracker list before `removeView` has actually detached the views.
- `forceClearAllOverlays` collapses to a `clearAllOverlays` alias since both paths are now equivalent.

### Cleanup
- Pending clear runnable is cancelled in all teardown paths (`reloadRulesFromSource`, `reevaluateBlockingState`, screen off, `onInterrupt`, `onDestroy`).

### Considered and rejected
- Per-element grace period (e.g. keep an overlay alive 500ms past its node's last appearance): would pin overlays at stale positions while a feed scrolls beneath them (Instagram-style), which is a worse artifact than a brief flicker.
- Widening `info.packageNames = null` to receive events for unmonitored apps: would fix the case where a switch never delivers an event to the service, but increases battery cost on every other app.

## Test plan
- [ ] Open WhatsApp with a rule active; pull and release the notification shade quickly. Overlay should not disappear.
- [ ] Open WhatsApp with a rule active; let a notification arrive without pulling the shade. Overlay should not flicker.
- [ ] Scroll the Instagram feed (or similar) with a rule active. Overlays should follow scrolled elements without sticking at stale positions.
- [ ] Switch from a rule app to launcher. Overlays should clear within ~150ms.
- [ ] Switch from a rule app to another rule app. Overlays for the first should clear, the second's should appear.
- [ ] Lock screen, then unlock and return to the rule app. Overlays should re-evaluate correctly.

https://claude.ai/code/session_018ChatjS8SFHCh8w7ySjCte