### PR TITLE
Merge two-part rules into one switch, and fix the rule state migration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,11 @@ The seam is `BaseDistractionControlService` (abstract, in the lib) ← `Distract
 
 ## Rule pipeline
 
-A rule is a single line of ad-block-style text, and that line string is the rule's identity: `FilterRule.equals`/`hashCode` are defined purely on `ruleString`, and `ServiceConfig` uses `rule.hashCode()` as the SharedPreferences key suffix for enabled/paused state. **Editing a rule line in `distraction_rules.txt` silently orphans every user's saved state for that rule.** Treat rule strings as stable identifiers.
+A rule is a single line of ad-block-style text. `FilterRule.equals`/`hashCode` are defined purely on `ruleString`, but saved state is *not*: `ServiceConfig` keys enabled/paused prefs on `FilterRule.identity()`, built only from the matching fields (`viewId`, `desc`, `path`, `className`, `text`, `blockTouches`) plus the package. So `comment`, `category` and `color` are free to edit — **but changing a matching field silently orphans every user's saved state for that rule.**
+
+The legacy scheme (prefs keyed on `ruleString.hashCode()`) is migrated in `ServiceConfig.migrateRuleKeys()`. Because legacy keys hash the *text*, they can only be recomputed from the text that shipped, so `assets/legacy_rules_v0.txt` holds a frozen copy of the 0.9.1 rules per flavour. **Never edit those snapshots**; if `PREFS_VERSION` is bumped again, add a new one. `ServiceConfigTest.everySnapshotRuleStillExistsInTheBundledRules` fails if a bundled rule's matching fields drift away from the snapshot.
+
+Rules in the same package that share a `comment` are rendered as a **single row** in the UI (`RulesAdapter.mergeRules`) and enabled/paused/disabled as a unit — that's how one user-facing switch is backed by several rules (e.g. Instagram's feed needs two sibling containers). Merging ignores `category` and never merges comment-less rules.
 
 Format (see `docs/CUSTOM_RULES.md` for user-facing docs):
 

--- a/app/src/gmwaylite/assets/legacy_rules_v0.txt
+++ b/app/src/gmwaylite/assets/legacy_rules_v0.txt
@@ -1,0 +1,7 @@
+// FROZEN SNAPSHOT -- DO NOT EDIT. See app/src/main/assets/legacy_rules_v0.txt.
+// The GMWay Lite rules exactly as shipped in version 0.9.1 (versionCode 26033101).
+com.whatsapp##viewId=com.whatsapp:id/search_meta_ai_input_send_button##desc=##comment=Hide AI suggestions in search
+com.whatsapp##viewId=com.whatsapp:id/extended_mini_fab##desc=##comment=Hide AI button
+com.whatsapp##viewId=com.whatsapp:id/newsletter_directory_row_container##comment=Hide recommended channels
+com.whatsapp##path=android.view.ViewGroup[0]>android.widget.FrameLayout[1]##comment=Hide Updates button
+com.whatsapp##path=androidx.viewpager.widget.ViewPager[0]>androidx.recyclerview.widget.RecyclerView[0]>android.widget.RelativeLayout[*]##comment=Hide channels

--- a/app/src/main/assets/distraction_rules.txt
+++ b/app/src/main/assets/distraction_rules.txt
@@ -1,8 +1,8 @@
 com.instagram.android##category=Stories##desc=reels tray container##comment=Hide Stories
 com.instagram.android##category=Reels##viewId=com.instagram.android:id/clips_tab##desc=##comment=Hide Reels button
 com.instagram.android##category=Search##path=androidx.viewpager.widget.ViewPager[0]>android.widget.FrameLayout[3]>androidx.recyclerview.widget.RecyclerView[0]>android.widget.FrameLayout[*]##comment=Hide search suggestions
-com.instagram.android##category=Feed##path=androidx.viewpager.widget.ViewPager[0]>android.widget.FrameLayout[0]>androidx.recyclerview.widget.RecyclerView[0]>android.view.ViewGroup[*]##comment=Hide feed 1/2
-com.instagram.android##category=Feed##path=androidx.viewpager.widget.ViewPager[0]>android.widget.FrameLayout[0]>androidx.recyclerview.widget.RecyclerView[0]>android.widget.FrameLayout[*]##comment=Hide feed 2/2
+com.instagram.android##category=Feed##path=androidx.viewpager.widget.ViewPager[0]>android.widget.FrameLayout[0]>androidx.recyclerview.widget.RecyclerView[0]>android.view.ViewGroup[*]##comment=Hide feed
+com.instagram.android##category=Feed##path=androidx.viewpager.widget.ViewPager[0]>android.widget.FrameLayout[0]>androidx.recyclerview.widget.RecyclerView[0]>android.widget.FrameLayout[*]##comment=Hide feed
 com.instagram.android##category=Reels##viewId=com.instagram.android:id/root_clips_layout##desc=##comment=Hide Reels layout
 com.instagram.android##category=Main screen##viewId=android:id/list##comment=Hide main screen
 com.linkedin.android##category=Feed##viewId=com.linkedin.android:id/feed_item_update_card##comment=Hide feed item##blockTouches=false

--- a/app/src/main/assets/legacy_rules_v0.txt
+++ b/app/src/main/assets/legacy_rules_v0.txt
@@ -1,0 +1,23 @@
+// FROZEN SNAPSHOT -- DO NOT EDIT.
+// The bundled rules exactly as shipped in version 0.9.1 (versionCode 26033101),
+// the last release that keyed saved rule state on ruleString.hashCode().
+// ServiceConfig.migrateRuleKeys() uses these lines to recover that state: it
+// hashes each line to find the legacy preference key, then re-files the value
+// under the rule's identity-derived key. Editing a line here orphans the
+// enabled/pause state of every user upgrading from 0.9.1.
+// If PREFS_VERSION is ever bumped again, add a new snapshot rather than
+// touching this one.
+com.instagram.android##desc=reels tray container##comment=Hide Stories
+com.instagram.android##viewId=com.instagram.android:id/clips_tab##desc=##comment=Hide Reels button
+com.instagram.android##path=androidx.viewpager.widget.ViewPager[0]>android.widget.FrameLayout[3]>androidx.recyclerview.widget.RecyclerView[0]>android.widget.FrameLayout[*]##comment=Hide search suggestions
+com.instagram.android##path=androidx.viewpager.widget.ViewPager[0]>android.widget.FrameLayout[0]>androidx.recyclerview.widget.RecyclerView[0]>android.view.ViewGroup[*]##comment=Hide feed 1/2
+com.instagram.android##path=androidx.viewpager.widget.ViewPager[0]>android.widget.FrameLayout[0]>androidx.recyclerview.widget.RecyclerView[0]>android.widget.FrameLayout[*]##comment=Hide feed 2/2
+com.instagram.android##viewId=com.instagram.android:id/root_clips_layout##desc=##comment=Hide Reels layout
+com.instagram.android##viewId=android:id/list##comment=Hide main screen
+com.linkedin.android##viewId=com.linkedin.android:id/feed_item_update_card##comment=Hide feed item##blockTouches=false
+com.linkedin.android##viewId=com.linkedin.android:id/tab_notifications##comment=Hide notifications
+com.whatsapp##viewId=com.whatsapp:id/search_meta_ai_input_send_button##desc=##comment=Hide AI suggestions in search
+com.whatsapp##viewId=com.whatsapp:id/extended_mini_fab##desc=##comment=Hide AI button
+com.whatsapp##viewId=com.whatsapp:id/newsletter_directory_row_container##comment=Hide recommended channels
+com.whatsapp##path=android.view.ViewGroup[0]>android.widget.FrameLayout[1]##comment=Hide Updates button
+com.whatsapp##path=androidx.viewpager.widget.ViewPager[0]>androidx.recyclerview.widget.RecyclerView[0]>android.widget.RelativeLayout[*]##comment=Hide channels

--- a/app/src/main/java/net/kollnig/greasemilkyway/RulesAdapter.java
+++ b/app/src/main/java/net/kollnig/greasemilkyway/RulesAdapter.java
@@ -628,6 +628,11 @@ public class RulesAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
      * Rules without a comment never merge: they fall back to a shared
      * placeholder name, which would otherwise collapse every unlabelled custom
      * rule into one row.
+     *
+     * <p>A custom rule never merges with a built-in one even if they share a
+     * comment: a mixed row can't be deleted (the delete path requires every
+     * part to be custom) and toggling it would silently flip the user's own
+     * rule along with the built-in one.
      */
     static List<List<FilterRule>> mergeRules(List<FilterRule> rules) {
         List<List<FilterRule>> rows = new ArrayList<>();
@@ -640,10 +645,11 @@ public class RulesAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
                 rows.add(row);
                 continue;
             }
-            List<FilterRule> row = byComment.get(comment);
+            String key = rule.isCustom + " " + comment;
+            List<FilterRule> row = byComment.get(key);
             if (row == null) {
                 row = new ArrayList<>();
-                byComment.put(comment, row);
+                byComment.put(key, row);
                 rows.add(row);
             }
             row.add(rule);

--- a/app/src/main/java/net/kollnig/greasemilkyway/RulesAdapter.java
+++ b/app/src/main/java/net/kollnig/greasemilkyway/RulesAdapter.java
@@ -95,8 +95,9 @@ public class RulesAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
         Map<Integer, FilterRule> existingRules = new HashMap<>();
         for (Object item : items) {
             if (item instanceof RuleItem) {
-                FilterRule rule = ((RuleItem) item).rule;
-                existingRules.put(rule.hashCode(), rule);
+                for (FilterRule rule : ((RuleItem) item).parts) {
+                    existingRules.put(rule.hashCode(), rule);
+                }
             }
         }
 
@@ -127,27 +128,31 @@ public class RulesAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
                 return d1.compareToIgnoreCase(d2);
             });
 
+            // Merge before counting, so the header's "hides N elements" agrees
+            // with the number of switches shown underneath it.
+            List<List<FilterRule>> packageRows = mergeRules(packageRules);
+
             // Count only enabled rules
             int enabledCount = 0;
-            for (FilterRule rule : packageRules) {
-                if (rule.enabled) enabledCount++;
+            for (List<FilterRule> row : packageRows) {
+                if (isRowEnabled(row)) enabledCount++;
             }
 
             // Add app header
-            items.add(new AppHeaderItem(packageName, enabledCount, packageRules.size()));
+            items.add(new AppHeaderItem(packageName, enabledCount, packageRows.size()));
 
             // Show rules only when the package is enabled (not disabled)
             boolean isPackageEnabled = !config.isPackageDisabled(packageName);
             if (isPackageEnabled) {
-                Map<String, List<FilterRule>> groupedRules = groupRules(packageRules);
-                for (Map.Entry<String, List<FilterRule>> group : groupedRules.entrySet()) {
+                Map<String, List<List<FilterRule>>> groupedRows = groupRows(packageRows);
+                for (Map.Entry<String, List<List<FilterRule>>> group : groupedRows.entrySet()) {
                     String groupTitle = group.getKey();
-                    List<FilterRule> groupRules = group.getValue();
+                    List<List<FilterRule>> groupRows = group.getValue();
                     boolean expanded = isRuleGroupExpanded(packageName, groupTitle);
-                    items.add(new RuleSectionItem(packageName, groupTitle, groupRules, expanded));
+                    items.add(new RuleSectionItem(packageName, groupTitle, groupRows, expanded));
                     if (expanded) {
-                        for (FilterRule rule : groupRules) {
-                            items.add(new RuleItem(rule));
+                        for (List<FilterRule> row : groupRows) {
+                            items.add(new RuleItem(row));
                         }
                     }
                 }
@@ -337,7 +342,7 @@ public class RulesAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
             RuleSectionViewHolder viewHolder = (RuleSectionViewHolder) holder;
             RuleSectionItem section = (RuleSectionItem) item;
             viewHolder.sectionTitle.setText(section.title);
-            viewHolder.sectionCount.setText(getRuleGroupSummary(section.rules));
+            viewHolder.sectionCount.setText(getRuleGroupSummary(section.rows));
             viewHolder.sectionIndicator.setText(section.expanded ? "v" : ">");
             viewHolder.itemView.setOnClickListener(v -> {
                 collapsePrefs.edit()
@@ -349,23 +354,32 @@ public class RulesAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
         } else if (holder instanceof RuleViewHolder && item instanceof RuleItem) {
             RuleViewHolder viewHolder = (RuleViewHolder) holder;
             RuleItem ruleItem = (RuleItem) item;
-            FilterRule rule = ruleItem.rule;
+            List<FilterRule> parts = ruleItem.parts;
+            FilterRule rule = ruleItem.primary();
+            // A row counts as on only when every part of it is: a partially
+            // applied row would leave whatever it hides visible anyway.
+            boolean rowEnabled = isRowEnabled(parts);
 
             viewHolder.ruleDescription.setText(getRuleDisplayName(rule));
 
+            long pausedUntil = 0;
+            for (FilterRule part : parts) {
+                if (part.isPaused && part.pausedUntil > pausedUntil) {
+                    pausedUntil = part.pausedUntil;
+                }
+            }
+
             // Set subtitle text based on state
-            if (rule.enabled) {
+            if (rowEnabled) {
                 viewHolder.ruleDetails.setVisibility(View.GONE);
-            } else if (rule.isPaused && rule.pausedUntil > System.currentTimeMillis()) {
+            } else if (pausedUntil > System.currentTimeMillis()) {
                 SimpleDateFormat sdf = new SimpleDateFormat("HH:mm", Locale.getDefault());
-                String timeStr = sdf.format(new Date(rule.pausedUntil));
+                String timeStr = sdf.format(new Date(pausedUntil));
                 viewHolder.ruleDetails.setText(context.getString(R.string.paused_until, timeStr));
                 viewHolder.ruleDetails.setVisibility(View.VISIBLE);
-            } else if (!rule.enabled) {
+            } else {
                 viewHolder.ruleDetails.setText(R.string.rule_disabled);
                 viewHolder.ruleDetails.setVisibility(View.VISIBLE);
-            } else {
-                viewHolder.ruleDetails.setVisibility(View.GONE);
             }
 
             // Check if the package is disabled
@@ -374,7 +388,7 @@ public class RulesAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
             // Remove any existing listener to prevent duplicate callbacks
             viewHolder.ruleSwitch.setOnCheckedChangeListener(null);
             // Set the current state
-            viewHolder.ruleSwitch.setChecked(rule.enabled);
+            viewHolder.ruleSwitch.setChecked(rowEnabled);
             // Disable the switch if the package is disabled
             viewHolder.ruleSwitch.setEnabled(!isPackageDisabled);
             // Add the listener back
@@ -384,24 +398,29 @@ public class RulesAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
                     return;
                 Object currentItem = items.get(adapterPosition);
                 if (currentItem instanceof RuleItem) {
-                    RuleItem currentRuleItem = (RuleItem) currentItem;
-                    FilterRule currentRule = currentRuleItem.rule;
-                    if (currentRule.enabled != isChecked) { // Only update if the state actually changed
+                    List<FilterRule> currentParts = ((RuleItem) currentItem).parts;
+                    if (isRowEnabled(currentParts) != isChecked) { // Only update if the state actually changed
                         if (!isChecked) {
                             // Intercept disabling
                             viewHolder.ruleSwitch.setOnCheckedChangeListener(null);
                             viewHolder.ruleSwitch.setChecked(true); // Revert visually
-                            
+
                             if (context instanceof MainActivity) {
-                                ((MainActivity) context).runWithFrictionGate("Disable Rule", () -> showPauseDialog(currentRule.packageName, currentRule));
+                                ((MainActivity) context).runWithFrictionGate("Disable Rule",
+                                        () -> showPauseDialog(currentParts.get(0).packageName, currentParts));
                             }
                             return;
                         }
 
-                        currentRule.enabled = true;
-                        currentRule.isPaused = false;
-                        config.setRuleEnabled(currentRule, true);
-                        config.setRulePausedUntil(currentRule, 0);
+                        // Every part of the row moves together, so a row can
+                        // never end up half applied.
+                        for (FilterRule part : currentParts) {
+                            part.enabled = true;
+                            part.isPaused = false;
+                            part.pausedUntil = 0;
+                            config.setRuleEnabled(part, true);
+                            config.setRulePausedUntil(part, 0);
+                        }
 
                         // Rebuild to update the package switch UI, showing rules, and updated counts
                         rebuildItemsList();
@@ -414,16 +433,27 @@ public class RulesAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
 
             // Set up long click to delete custom rules
             viewHolder.itemView.setOnLongClickListener(v -> {
-                if (rule.isCustom) {
+                // A merged row is only deletable if it is custom throughout;
+                // deleting half of it would leave an orphaned built-in part.
+                boolean allCustom = true;
+                for (FilterRule part : parts) {
+                    if (!part.isCustom) {
+                        allCustom = false;
+                        break;
+                    }
+                }
+                if (allCustom) {
                     if (context instanceof MainActivity) {
                         ((MainActivity) context).runWithFrictionGate("Delete Rule", () -> new AlertDialog.Builder(context)
                                 .setTitle(R.string.delete_rule_title)
                                 .setMessage(R.string.delete_rule_message)
                                 .setPositiveButton(R.string.delete_rule_confirm, (dialog, which) -> {
-                                    config.removeCustomRule(rule.ruleString);
+                                    for (FilterRule part : parts) {
+                                        config.removeCustomRule(part.ruleString);
 
-                                    // Clean up the current rules list
-                                    currentRules.remove(rule);
+                                        // Clean up the current rules list
+                                        currentRules.remove(part);
+                                    }
 
                                     // Check if we need to disable the package if it was the last rule
                                     boolean anyRulesStillEnabled = false;
@@ -510,7 +540,10 @@ public class RulesAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
         }
     }
 
-    private void showPauseDialog(String packageName, FilterRule rule) {
+    /**
+     * @param rules the parts of a single row, or null to act on the whole package
+     */
+    private void showPauseDialog(String packageName, List<FilterRule> rules) {
         int durationMins = config.getPauseDurationMins();
         String message = "Do you want to pause for " + durationMins + " minutes or disable permanently?";
         
@@ -518,13 +551,15 @@ public class RulesAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
                 .setTitle("Disable Rule")
                 .setMessage(message)
                 .setPositiveButton("Pause (" + durationMins + "m)", (dialog, which) -> {
-                    if (rule != null) {
+                    if (rules != null) {
                         long until = System.currentTimeMillis() + (durationMins * 60 * 1000L);
-                        config.setRuleEnabled(rule, false);
-                        config.setRulePausedUntil(rule, until);
-                        rule.enabled = false;
-                        rule.isPaused = true;
-                        rule.pausedUntil = until;
+                        for (FilterRule rule : rules) {
+                            config.setRuleEnabled(rule, false);
+                            config.setRulePausedUntil(rule, until);
+                            rule.enabled = false;
+                            rule.isPaused = true;
+                            rule.pausedUntil = until;
+                        }
                     } else {
                         long until = PauseManager.applyPackagePause(context, packageName);
                         // Update in-memory state for UI only; individual rule prefs are
@@ -538,17 +573,19 @@ public class RulesAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
                         }
                     }
                     rebuildItemsList();
-                    if (rule != null) {
+                    if (rules != null) {
                         notifyService();
                     }
                 })
                 .setNeutralButton("Disable Permanently", (dialog, which) -> {
-                    if (rule != null) {
-                        config.setRuleEnabled(rule, false);
-                        config.setRulePausedUntil(rule, 0);
-                        rule.enabled = false;
-                        rule.isPaused = false;
-                        rule.pausedUntil = 0;
+                    if (rules != null) {
+                        for (FilterRule rule : rules) {
+                            config.setRuleEnabled(rule, false);
+                            config.setRulePausedUntil(rule, 0);
+                            rule.enabled = false;
+                            rule.isPaused = false;
+                            rule.pausedUntil = 0;
+                        }
                     } else {
                         config.setPackageDisabled(packageName, true);
                         config.setPackagePausedUntil(packageName, 0);
@@ -577,12 +614,58 @@ public class RulesAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
         }
     }
 
-    private Map<String, List<FilterRule>> groupRules(List<FilterRule> rules) {
-        Map<String, List<FilterRule>> groups = new java.util.LinkedHashMap<>();
+    /**
+     * Collapses rules that share a comment into a single row.
+     *
+     * <p>Some things a user thinks of as one switch need more than one rule to
+     * hide -- Instagram's feed, for instance, is two sibling containers with
+     * different classes. Giving those rules the same comment is what marks
+     * them as parts of one whole; the row then acts on all of its parts at
+     * once, so a half-hidden feed is not a state the UI can produce.
+     *
+     * <p>Merging deliberately ignores category, so parts filed under different
+     * categories still merge rather than silently appearing as two half-rows.
+     * Rules without a comment never merge: they fall back to a shared
+     * placeholder name, which would otherwise collapse every unlabelled custom
+     * rule into one row.
+     */
+    static List<List<FilterRule>> mergeRules(List<FilterRule> rules) {
+        List<List<FilterRule>> rows = new ArrayList<>();
+        Map<String, List<FilterRule>> byComment = new java.util.LinkedHashMap<>();
         for (FilterRule rule : rules) {
-            groups.computeIfAbsent(getRuleGroup(rule), k -> new ArrayList<>()).add(rule);
+            String comment = rule.description == null ? "" : rule.description.trim();
+            if (comment.isEmpty()) {
+                List<FilterRule> row = new ArrayList<>();
+                row.add(rule);
+                rows.add(row);
+                continue;
+            }
+            List<FilterRule> row = byComment.get(comment);
+            if (row == null) {
+                row = new ArrayList<>();
+                byComment.put(comment, row);
+                rows.add(row);
+            }
+            row.add(rule);
+        }
+        return rows;
+    }
+
+    private Map<String, List<List<FilterRule>>> groupRows(List<List<FilterRule>> rows) {
+        Map<String, List<List<FilterRule>>> groups = new java.util.LinkedHashMap<>();
+        for (List<FilterRule> row : rows) {
+            groups.computeIfAbsent(getRuleGroup(row.get(0)), k -> new ArrayList<>()).add(row);
         }
         return groups;
+    }
+
+    static boolean isRowEnabled(List<FilterRule> row) {
+        for (FilterRule rule : row) {
+            if (!rule.enabled) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private String getRuleGroup(FilterRule rule) {
@@ -605,22 +688,23 @@ public class RulesAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
         return context.getString(R.string.rule_builtin_fallback);
     }
 
-    private String getRuleGroupSummary(List<FilterRule> rules) {
+    /** Counts merged rows rather than rules, to match what the section shows. */
+    private String getRuleGroupSummary(List<List<FilterRule>> rows) {
         int enabledCount = 0;
-        for (FilterRule rule : rules) {
-            if (rule.enabled) {
+        for (List<FilterRule> row : rows) {
+            if (isRowEnabled(row)) {
                 enabledCount++;
             }
         }
         if (enabledCount == 0) {
             return context.getResources().getQuantityString(R.plurals.disabled_rule_count,
-                    rules.size(), rules.size());
+                    rows.size(), rows.size());
         }
-        if (enabledCount == rules.size()) {
+        if (enabledCount == rows.size()) {
             return context.getResources().getQuantityString(R.plurals.active_rule_count,
                     enabledCount, enabledCount);
         }
-        return context.getString(R.string.active_rule_fraction, enabledCount, rules.size());
+        return context.getString(R.string.active_rule_fraction, enabledCount, rows.size());
     }
 
     private boolean isRuleGroupExpanded(String packageName, String title) {
@@ -649,11 +733,19 @@ public class RulesAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
         }
     }
 
+    /**
+     * One row of the rules list. Usually a single rule, but rules sharing a
+     * comment are presented -- and acted on -- as one; see {@link #mergeRules}.
+     */
     private static class RuleItem {
-        final FilterRule rule;
+        final List<FilterRule> parts;
 
-        RuleItem(FilterRule rule) {
-            this.rule = rule;
+        RuleItem(List<FilterRule> parts) {
+            this.parts = parts;
+        }
+
+        FilterRule primary() {
+            return parts.get(0);
         }
     }
 
@@ -663,13 +755,14 @@ public class RulesAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
     private static class RuleSectionItem {
         final String packageName;
         final String title;
-        final List<FilterRule> rules;
+        final List<List<FilterRule>> rows;
         final boolean expanded;
 
-        RuleSectionItem(String packageName, String title, List<FilterRule> rules, boolean expanded) {
+        RuleSectionItem(String packageName, String title, List<List<FilterRule>> rows,
+                        boolean expanded) {
             this.packageName = packageName;
             this.title = title;
-            this.rules = rules;
+            this.rows = rows;
             this.expanded = expanded;
         }
     }

--- a/app/src/main/java/net/kollnig/greasemilkyway/ServiceConfig.java
+++ b/app/src/main/java/net/kollnig/greasemilkyway/ServiceConfig.java
@@ -32,6 +32,11 @@ public class ServiceConfig {
     private static final String KEY_NOTIFICATION_TIMEOUT_MS = "notification_timeout_ms";
     private static final String KEY_PREFS_VERSION = "prefs_version";
     private static final String DEFAULT_RULES_FILE = "distraction_rules.txt";
+    /**
+     * The bundled rules as shipped by the last release that used legacy
+     * preference keys. Frozen; see the file's own header.
+     */
+    private static final String LEGACY_RULES_V0_FILE = "legacy_rules_v0.txt";
     /** 1: rule keys derived from rule identity rather than ruleString.hashCode(). */
     private static final int PREFS_VERSION = 1;
 
@@ -72,6 +77,29 @@ public class ServiceConfig {
         }
     }
 
+    /**
+     * Reads a bundled rules file, dropping blank lines. Returns null -- as
+     * distinct from an empty list -- if the asset could not be read at all,
+     * since callers treat a failed read as "rule set incomplete" rather than
+     * "no rules".
+     */
+    private List<String> readAssetLines(String assetName) {
+        List<String> lines = new ArrayList<>();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(
+                context.getAssets().open(assetName), StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (!line.trim().isEmpty()) {
+                    lines.add(line);
+                }
+            }
+            return lines;
+        } catch (IOException e) {
+            Log.e(TAG, "Failed to read " + assetName, e);
+            return null;
+        }
+    }
+
     public void setRuleEnabled(FilterRule rule, boolean enabled) {
         String key = KEY_RULE_ENABLED + ruleKeySuffix(rule);
         prefs.edit().putBoolean(key, enabled).apply();
@@ -97,6 +125,18 @@ public class ServiceConfig {
      * upgrading would silently reset every rule the user had enabled or
      * paused.
      *
+     * <p>The legacy key is the hash of the rule's <em>text</em>, so it can
+     * only be recomputed from the text the user's previous version shipped,
+     * not from the current rules: bundled rule lines get edited between
+     * releases (adding a category, fixing a comment) without that being meant
+     * to reset anything. {@link #LEGACY_RULES_V0_FILE} therefore holds a
+     * frozen copy of the rules as last shipped under the old scheme, and the
+     * legacy keys are derived from those lines. Their destination is the
+     * identity-derived key, which is unaffected by such edits, so the state
+     * lands on the current rule regardless of how its text has changed.
+     * {@code knownRules} is migrated too, which is what covers custom rules:
+     * those are stored verbatim, so their text is its own snapshot.
+     *
      * <p>{@code completeRuleSet} must be false whenever {@code knownRules}
      * might be missing rules -- e.g. the bundled rules file failed to load.
      * In that case legacy keys for the rules present (typically just custom
@@ -109,8 +149,14 @@ public class ServiceConfig {
             return;
         }
 
+        List<FilterRule> toMigrate = new ArrayList<>(knownRules);
+        List<String> legacyLines = readAssetLines(LEGACY_RULES_V0_FILE);
+        if (legacyLines != null && !legacyLines.isEmpty()) {
+            toMigrate.addAll(ruleParser.parseRules(legacyLines.toArray(new String[0])));
+        }
+
         SharedPreferences.Editor editor = prefs.edit();
-        for (FilterRule rule : knownRules) {
+        for (FilterRule rule : toMigrate) {
             String legacy = String.valueOf(rule.ruleString.hashCode());
             String current = ruleKeySuffix(rule);
 
@@ -132,7 +178,9 @@ public class ServiceConfig {
                 editor.remove(legacyPause);
             }
         }
-        if (completeRuleSet) {
+        // A missing snapshot leaves the bundled rules' legacy state untouched,
+        // which is the same partial-migration case as a missing rules file.
+        if (completeRuleSet && legacyLines != null) {
             editor.putInt(KEY_PREFS_VERSION, PREFS_VERSION);
         }
         editor.apply();
@@ -164,21 +212,9 @@ public class ServiceConfig {
         // Add default rules from file. Collected first and parsed in one call:
         // parsing line by line allocated a single-element array and re-entered
         // the parser for every rule in the file.
-        List<String> defaultRuleLines = new ArrayList<>();
-        boolean defaultRulesReadOk = false;
-        try (BufferedReader reader = new BufferedReader(
-                new InputStreamReader(context.getAssets().open(DEFAULT_RULES_FILE)))) {
-            String line;
-            while ((line = reader.readLine()) != null) {
-                if (!line.trim().isEmpty()) {
-                    defaultRuleLines.add(line);
-                }
-            }
-            defaultRulesReadOk = true;
-        } catch (IOException e) {
-            Log.e(TAG, "Failed to read " + DEFAULT_RULES_FILE, e);
-        }
-        if (!defaultRuleLines.isEmpty()) {
+        List<String> defaultRuleLines = readAssetLines(DEFAULT_RULES_FILE);
+        boolean defaultRulesReadOk = defaultRuleLines != null;
+        if (defaultRuleLines != null && !defaultRuleLines.isEmpty()) {
             rules.addAll(ruleParser.parseRules(defaultRuleLines.toArray(new String[0])));
         }
 

--- a/app/src/test/java/net/kollnig/greasemilkyway/RulesAdapterTest.java
+++ b/app/src/test/java/net/kollnig/greasemilkyway/RulesAdapterTest.java
@@ -1,0 +1,112 @@
+package net.kollnig.greasemilkyway;
+
+import net.kollnig.distractionlib.FilterRule;
+import net.kollnig.distractionlib.FilterRuleParser;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * Covers the rule merging that lets several rules appear as one switch.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class RulesAdapterTest {
+
+    private List<FilterRule> parse(String... ruleStrings) {
+        return new FilterRuleParser().parseRules(ruleStrings);
+    }
+
+    @Test
+    public void rulesSharingACommentBecomeOneRow() {
+        List<List<FilterRule>> rows = RulesAdapter.mergeRules(parse(
+                "com.example.app##path=A[*]##comment=Hide feed",
+                "com.example.app##path=B[*]##comment=Hide feed"));
+
+        assertEquals(1, rows.size());
+        assertEquals(2, rows.get(0).size());
+    }
+
+    @Test
+    public void rulesWithDifferentCommentsStaySeparate() {
+        List<List<FilterRule>> rows = RulesAdapter.mergeRules(parse(
+                "com.example.app##path=A[*]##comment=Hide feed",
+                "com.example.app##path=B[*]##comment=Hide stories"));
+
+        assertEquals(2, rows.size());
+    }
+
+    /**
+     * Categories only decide which section a row is filed under. If two parts
+     * of one thing were given different categories, merging on category too
+     * would split them back into two half-rows.
+     */
+    @Test
+    public void differingCategoriesDoNotPreventMerging() {
+        List<List<FilterRule>> rows = RulesAdapter.mergeRules(parse(
+                "com.example.app##category=Feed##path=A[*]##comment=Hide feed",
+                "com.example.app##category=Main screen##path=B[*]##comment=Hide feed"));
+
+        assertEquals(1, rows.size());
+    }
+
+    /**
+     * The element picker omits the comment when the user leaves the label
+     * blank, and those rules all fall back to the same placeholder name.
+     */
+    @Test
+    public void rulesWithoutCommentsNeverMerge() {
+        List<List<FilterRule>> rows = RulesAdapter.mergeRules(parse(
+                "com.example.app##path=A[*]",
+                "com.example.app##path=B[*]"));
+
+        assertEquals(2, rows.size());
+    }
+
+    @Test
+    public void mergedRowKeepsThePositionOfItsFirstPart() {
+        List<List<FilterRule>> rows = RulesAdapter.mergeRules(parse(
+                "com.example.app##path=A[*]##comment=Hide ads",
+                "com.example.app##path=B[*]##comment=Hide feed",
+                "com.example.app##path=C[*]##comment=Hide ads"));
+
+        assertEquals(2, rows.size());
+        assertEquals("Hide ads", rows.get(0).get(0).description);
+        assertEquals(2, rows.get(0).size());
+        assertEquals("Hide feed", rows.get(1).get(0).description);
+    }
+
+    @Test
+    public void rowIsOnlyEnabledWhenEveryPartIs() {
+        List<FilterRule> row = parse(
+                "com.example.app##path=A[*]##comment=Hide feed",
+                "com.example.app##path=B[*]##comment=Hide feed");
+
+        row.get(0).enabled = true;
+        row.get(1).enabled = false;
+        assertFalse(RulesAdapter.isRowEnabled(row));
+
+        row.get(1).enabled = true;
+        assertTrue(RulesAdapter.isRowEnabled(row));
+    }
+
+    /**
+     * The bundled Instagram feed needs two rules -- sibling containers with
+     * different classes -- and is the case this merging exists for.
+     */
+    @Test
+    public void bundledFeedRulesMergeIntoOneRow() {
+        List<FilterRule> feedRules = parse(
+                "com.instagram.android##category=Feed##path=androidx.viewpager.widget.ViewPager[0]>android.widget.FrameLayout[0]>androidx.recyclerview.widget.RecyclerView[0]>android.view.ViewGroup[*]##comment=Hide feed",
+                "com.instagram.android##category=Feed##path=androidx.viewpager.widget.ViewPager[0]>android.widget.FrameLayout[0]>androidx.recyclerview.widget.RecyclerView[0]>android.widget.FrameLayout[*]##comment=Hide feed");
+
+        List<List<FilterRule>> rows = RulesAdapter.mergeRules(feedRules);
+
+        assertEquals(1, rows.size());
+        assertEquals(2, rows.get(0).size());
+    }
+}

--- a/app/src/test/java/net/kollnig/greasemilkyway/RulesAdapterTest.java
+++ b/app/src/test/java/net/kollnig/greasemilkyway/RulesAdapterTest.java
@@ -109,4 +109,22 @@ public class RulesAdapterTest {
         assertEquals(1, rows.size());
         assertEquals(2, rows.get(0).size());
     }
+
+    /**
+     * A mixed row can't be deleted (deleting requires every part to be
+     * custom) and toggling it would silently flip the user's own rule along
+     * with the built-in one, so custom and built-in rules must never share a
+     * row even when their comments match.
+     */
+    @Test
+    public void customRuleNeverMergesWithABuiltInRuleSharingItsComment() {
+        List<FilterRule> rules = parse(
+                "com.example.app##path=A[*]##comment=Hide feed",
+                "com.example.app##path=B[*]##comment=Hide feed");
+        rules.get(1).isCustom = true;
+
+        List<List<FilterRule>> rows = RulesAdapter.mergeRules(rules);
+
+        assertEquals(2, rows.size());
+    }
 }

--- a/app/src/test/java/net/kollnig/greasemilkyway/ServiceConfigTest.java
+++ b/app/src/test/java/net/kollnig/greasemilkyway/ServiceConfigTest.java
@@ -11,8 +11,14 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.Assert.*;
 
@@ -416,5 +422,96 @@ public class ServiceConfigTest {
         config.getRules();
 
         assertFalse(config.isRuleEnabled(rule));
+    }
+
+    // --- Migration of bundled rules via the frozen 0.9.1 snapshot ---
+
+    private List<FilterRule> parseAsset(String assetName) {
+        List<String> lines = new ArrayList<>();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(
+                context.getAssets().open(assetName), StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (!line.trim().isEmpty()) {
+                    lines.add(line);
+                }
+            }
+        } catch (IOException e) {
+            throw new AssertionError("could not read " + assetName, e);
+        }
+        return new FilterRuleParser().parseRules(lines.toArray(new String[0]));
+    }
+
+    /**
+     * The snapshot only recovers a rule's state if that rule still exists with
+     * the same matching fields, since identity is what the state is re-filed
+     * under. Editing a bundled rule's viewId/desc/path/blockTouches therefore
+     * silently drops the saved state of everyone upgrading from 0.9.1 -- which
+     * is defensible for a rule that genuinely now targets something else, but
+     * must be a deliberate choice rather than a slip. Adding new rules is fine.
+     */
+    @Test
+    public void everySnapshotRuleStillExistsInTheBundledRules() {
+        Set<String> current = new HashSet<>();
+        for (FilterRule rule : parseAsset("distraction_rules.txt")) {
+            current.add(rule.identity());
+        }
+
+        for (FilterRule legacy : parseAsset("legacy_rules_v0.txt")) {
+            assertTrue("no bundled rule matches the 0.9.1 rule: " + legacy.ruleString,
+                    current.contains(legacy.identity()));
+        }
+    }
+
+    @Test
+    public void migrationCarriesOverBuiltInStateAcrossEditedRuleText() {
+        List<FilterRule> legacyRules = parseAsset("legacy_rules_v0.txt");
+        long pausedUntil = System.currentTimeMillis() + 60000;
+        for (FilterRule legacy : legacyRules) {
+            config.getPrefs().edit()
+                    .putBoolean(ServiceConfig.KEY_RULE_ENABLED + legacy.ruleString.hashCode(), true)
+                    .putLong("pause_until_rule_" + legacy.ruleString.hashCode(), pausedUntil)
+                    .apply();
+        }
+
+        List<FilterRule> rules = config.getRules();
+
+        for (FilterRule legacy : legacyRules) {
+            FilterRule current = null;
+            for (FilterRule rule : rules) {
+                if (rule.identity().equals(legacy.identity())) {
+                    current = rule;
+                    break;
+                }
+            }
+            assertNotNull("bundled rule missing for " + legacy.ruleString, current);
+            assertTrue("enabled state lost for " + legacy.ruleString,
+                    config.isRuleEnabled(current));
+            assertEquals("pause lost for " + legacy.ruleString,
+                    pausedUntil, config.getRulePausedUntil(current));
+        }
+    }
+
+    /**
+     * The case the snapshot exists for: the bundled feed rules gained a
+     * category and had their comments merged after 0.9.1, so their text-derived
+     * legacy keys no longer match what users have stored.
+     */
+    @Test
+    public void migrationHandlesBundledRulesWhoseTextChangedSinceRelease() {
+        boolean sawEditedRule = false;
+        Set<String> currentText = new HashSet<>();
+        for (FilterRule rule : parseAsset("distraction_rules.txt")) {
+            currentText.add(rule.ruleString);
+        }
+        for (FilterRule legacy : parseAsset("legacy_rules_v0.txt")) {
+            if (!currentText.contains(legacy.ruleString)) {
+                sawEditedRule = true;
+                break;
+            }
+        }
+        assertTrue("expected at least one bundled rule to have been edited since 0.9.1; "
+                + "if none remain, migrationCarriesOverBuiltInStateAcrossEditedRuleText "
+                + "no longer proves the snapshot is doing anything", sawEditedRule);
     }
 }

--- a/docs/CUSTOM_RULES.md
+++ b/docs/CUSTOM_RULES.md
@@ -21,7 +21,9 @@ Common keys:
 - `desc`: match a content description
 - `path`: match a view hierarchy path
 - `category`: group related rules in the rule list
-- `comment`: add a human-readable note
+- `comment`: the name shown in the rule list. Rules for the same app that share
+  a comment appear as **one switch**, turned on and off together — useful when
+  hiding one thing takes more than one rule
 - `color`: optional fallback color
 - `blockTouches`: whether touches should pass through
 
@@ -31,6 +33,13 @@ Common keys:
 com.example.app##category=Feed##viewId=com.example.app:id/distracting_element##comment=Hide distracting panel
 com.example.app##category=Recommendations##desc=Recommended content##comment=Hide recommendation row
 com.example.app##category=Feed##path=android.widget.FrameLayout[0]>androidx.recyclerview.widget.RecyclerView[0]>android.view.ViewGroup[*]##comment=Hide feed cards
+```
+
+Two rules presented as a single "Hide feed" switch, because they share a comment:
+
+```text
+com.example.app##category=Feed##path=androidx.recyclerview.widget.RecyclerView[0]>android.view.ViewGroup[*]##comment=Hide feed
+com.example.app##category=Feed##path=androidx.recyclerview.widget.RecyclerView[0]>android.widget.FrameLayout[*]##comment=Hide feed
 ```
 
 ## Built-In Rules


### PR DESCRIPTION
Two related changes: the UI merge that was asked for, and a release-blocking migration bug found while checking whether the merge needed one.

## Fix the legacy rule state migration

`ServiceConfig.migrateRuleKeys()` derived each rule's legacy preference key by hashing its **current** text. That text had already moved on — `5f4c65b` added `##category=…` to all 14 bundled rules (and all 5 lite ones), and that commit is not in tag `26033101`, the released 0.9.1. So the computed legacy keys matched nothing a real user had stored: the migration silently no-opped for every bundled rule, and since rules are opt-in (`isRuleEnabled` defaults to `false`), everyone's enabled rules would have turned **off** on upgrade — failing in the unblocked direction. Custom rules were unaffected; they're stored verbatim.

Legacy keys hash the rule *text*, so they can only be recomputed from the text that actually shipped. `assets/legacy_rules_v0.txt` (per flavour) now holds a frozen copy of the 0.9.1 rules, and the migration derives legacy keys from that, writing the recovered value to the identity-derived key. Identity excludes `comment`, `category` and `color`, so state lands on the current rule no matter how much its presentational text has since changed — no hand-maintained old-line-to-new-line table.

A missing snapshot leaves the prefs version unbumped, matching the existing handling of a missing rules file.

## Show rules sharing a comment as one switch

Instagram's feed needs two rules — sibling containers with different classes — previously listed as `Hide feed 1/2` and `Hide feed 2/2`. Rules in a package that share a comment now render as a single row and are acted on as a unit: enable, pause, disable-permanently and delete all apply to every part, so a half-applied row isn't a state the UI can produce. Section counts and the app header count rows rather than rules.

Merging ignores `category` (so parts filed differently don't split into two half-rows) and never merges comment-less rules (they share a placeholder name, which would collapse every unlabelled picker-made rule into one row).

## Testing

`./gradlew testStandardDebugUnitTest :distractionlib:testDebugUnitTest lintStandardDebug assembleStandardDebug` all pass.

New coverage:
- all 14 bundled rules keep enabled and pause state across the text change;
- every snapshot rule still exists in the current rules — fails loudly if a bundled rule's matching fields ever drift, which is the one edit that genuinely does orphan state;
- a guard asserting at least one bundled rule's text *has* changed, so the migration test can't quietly stop proving anything;
- merge behaviour: same comment merges, different comments don't, differing categories still merge, comment-less rules never merge, a row is on only when every part is.

I verified the main migration test fails when the snapshot is unavailable, so it tests what it claims.

## Notes for review

- **`assets/legacy_rules_v0.txt` is frozen.** Editing it orphans the state of everyone upgrading from 0.9.1. If `PREFS_VERSION` is bumped again, add a new snapshot rather than touching this one.
- A user who had only *one* half of the feed enabled will see the merged row as off while the service still applies the enabled half. It self-corrects the first time they touch the switch. The alternatives are worse: "any part on" makes the switch understate blocking in the dangerous direction, and auto-enabling the missing half silently overrides a user's choice.
- `Hide Reels button` and `Hide Reels layout` are arguably one switch too, but merging them means changing user-visible labels, so I left them alone.
- AGENTS.md's rule-identity section was stale — it still described state as keyed on `ruleString.hashCode()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)