### PR TITLE
Remove two stale code inventories from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ The service is the fiddly part of the codebase, and most of the commit history i
 - `OverlayManager` is main-thread-only and synchronous by design — read its class comment before changing it.
 - The element picker suppresses blocking (`shouldProcessRules()` returns false) while it is active, so the user can tap the element they mean. Any new mode that draws its own UI over another app needs the same.
 
-The module seam is a rule, not just a layout. `:distractionlib` is app-agnostic and must not learn about SharedPreferences, notifications or activities: it asks the app through the abstract hooks on `BaseDistractionControlService` (`loadRules()`, `shouldProcessRules()`, `onServiceReady/Teardown()`, `onPauseNotificationShouldShow/Cancel()`), and the app drives it only through the `protected final` helpers (`reloadRulesFromSource()`, `reevaluateBlockingState()`, `clearCurrentOverlays()`). Reaching past that seam in either direction is the thing to avoid.
+The module seam is a rule, not just a layout. `:distractionlib` is app-agnostic and must not learn about SharedPreferences, notifications or activities: it asks the app for those through the hooks on `BaseDistractionControlService`, and the app drives it only through that class's `protected final` helpers. Both sets are declared together at the top of the class — read them there rather than trusting a list here. Reaching past the seam in either direction is the thing to avoid.
 
 ## Conventions and hazards
 
@@ -70,7 +70,7 @@ The module seam is a rule, not just a layout. `:distractionlib` is app-agnostic 
 - Any new path that unblocks something or opens settings goes through `MainActivity.runWithFrictionGate(...)`; a path that skips it quietly defeats the feature for the users who turned it on.
 - User-visible strings belong in `res/values/strings.xml`. If a string names the app, `gmwaylite` needs an override too.
 - Version bumps live in `app/build.gradle` (`versionCode`/`versionName`); store metadata is in `fastlane/metadata/android/`.
-- `LayoutDumper` is debug-only and hard-disabled (`ENABLED = false`). Leave it that way — it prints the contents of other apps' screens.
+- Never log or dump the contents of another app's screen, even behind a debug flag. The service can read every screen the user opens; a dumper existed once and was removed for this reason.
 - Edit the worktree that is actually being built, not another checkout.
 - GPLv3.
 


### PR DESCRIPTION
**Concern addressed:** AGENTS.md carries lists of symbols that have drifted from the tree.

**What changed and why:**

Two spots described the code rather than the constraint, and both were already wrong — which is the argument against carrying them at all. A symbol list in a doc goes stale silently and gets believed anyway.

*Module seam paragraph* — named the hooks and helpers exhaustively, and got both wrong:

- `onPauseNotificationShouldShow/Cancel()` were listed as **abstract hooks**. They are concrete no-ops with default implementations ([BaseDistractionControlService.java:162](../blob/main/distractionlib/src/main/java/net/kollnig/distractionlib/BaseDistractionControlService.java#L162)), so an agent trusting the doc would think a subclass is obliged to implement them.
- Three of the seven `protected final` helpers were listed, implying `getRulesSnapshot()` and `forceClearCurrentOverlays()` were off-limits.

The constraint the paragraph exists to state — the seam's direction, and that `:distractionlib` must not learn about SharedPreferences, notifications or activities — needs neither list, so it now points at the class instead.

*`LayoutDumper` bullet* — worse: b0b3bab "Remove the dead layout dumper" deleted that class, and the bullet still instructed the next agent to **leave it that way**. The privacy reason behind it is real and, with the class gone, no longer discoverable anywhere in the tree — so it stays as a forward-looking rule ("never dump another app's screen, even behind a debug flag") rather than a pointer to something that no longer exists.

**Evidence:** Documentation only — no code touched, so nothing to test. Each claim was checked against the tree before editing: `grep` for `protected abstract` / `protected final` in `BaseDistractionControlService` produced the actual sets, and `find`/`git log --all -- '*LayoutDumper*'` confirmed the class is gone and when. The other symbol anchors in the file (`CLEAR_OVERLAYS_DELAY_MS` = 150, `removeSentinelsIfIdle`, `runWithFrictionGate`, `everySnapshotRuleStillExistsInTheBundledRules`, the three `bools.xml` flags) were spot-checked in the same pass and are all still accurate.

**Not in this PR:** #32 sharpens this file's opening paragraph into an explicit test ("would an agent with the repo in front of it get this wrong without being told?") and applies it to the navigation-rules section it adds. This change is the same principle applied to `main`'s own prose, kept separate because that section does not exist here. The two touch different regions of the file and merge cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)